### PR TITLE
Round to the nearest second to avoid running commands twice

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -180,7 +180,7 @@ func (c *Cron) run() {
 			effective = c.entries[0].Next
 		}
 
-		timer := time.NewTimer(effective.Sub(now))
+		timer := time.NewTimer(effective.Sub(now).Round(time.Second))
 		select {
 		case now = <-timer.C:
 			now = now.In(c.location)


### PR DESCRIPTION
It's possible for commands to run twice due to rounding+sleep behavior if the interval is <1s (it seems most/only prevalent or Windows). I think this fixes it.